### PR TITLE
 Disable OUI refresh when the refresh interval is set to 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.0.6
+  - allow disabling refresh (when interval == 0) for performance
 ## 1.0.5
   - thread locking and refresh interval of oui file
 ## 1.0.4

--- a/lib/logstash/filters/ieee_oui.rb
+++ b/lib/logstash/filters/ieee_oui.rb
@@ -104,17 +104,19 @@ class LogStash::Filters::IeeeOui < LogStash::Filters::Base
 
   private
   def refreshfile(file)
-    @newmd5 = md5file(file)
-    if @newmd5 != @md5
-      @md5 = md5file(file)
+    newmd5 = md5file(file)
+    if @md5 != newmd5
+      @md5 = newmd5
       @ouihash = hashfile(file)
-      @next_refresh = Time.now + @refresh_interval
       @logger.info("Refreshing OUI file", :path => file)
+      @logger.info("OUI file MD5", :string => @md5)
+      @logger.info("OUI hash length", :number => @ouihash.length)
     else
       @logger.debug("OUI file unchanged", :path => file)
+      @logger.debug("OUI file MD5", :string => @md5)
+      @logger.debug("OUI hash length", :number => @ouihash.length)
     end
-    @logger.debug("OUI file MD5", :string => @md5)
-    @logger.info("OUI hash length", :number => @ouihash.length)
+    @next_refresh = Time.now + @refresh_interval
   end
 
   private

--- a/lib/logstash/filters/ieee_oui.rb
+++ b/lib/logstash/filters/ieee_oui.rb
@@ -108,14 +108,11 @@ class LogStash::Filters::IeeeOui < LogStash::Filters::Base
     if @md5 != newmd5
       @md5 = newmd5
       @ouihash = hashfile(file)
-      @logger.info("Refreshing OUI file", :path => file)
-      @logger.info("OUI file MD5", :string => @md5)
-      @logger.info("OUI hash length", :number => @ouihash.length)
+      @logger.info("Refreshed OUI file, hash entries", :number => @ouihash.length)
     else
-      @logger.debug("OUI file unchanged", :path => file)
-      @logger.debug("OUI file MD5", :string => @md5)
-      @logger.debug("OUI hash length", :number => @ouihash.length)
+      @logger.debug("OUI file unchanged, hash entries", :number => @ouihash.length)
     end
+    @logger.debug("OUI file MD5", :string => @md5)
     @next_refresh = Time.now + @refresh_interval
   end
 

--- a/logstash-filter-ieee_oui.gemspec
+++ b/logstash-filter-ieee_oui.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-filter-ieee_oui'
-  s.version       = '1.0.5'
+  s.version       = '1.0.6'
   s.licenses      = ['Apache-2.0']
   s.summary       = 'Logstash filter to parse OUI data from mac addresses, requires external OUI txt file from ieee.org'
   s.description   = 'This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program'


### PR DESCRIPTION
If you don't expect your oui.txt file to change much, this allows for the best performance as it can skip the read/write locking of the OUI hash.
